### PR TITLE
feat(ui): refactor DcPullRefresh with Bilibili-style visuals and improved touch handling

### DIFF
--- a/packages/ui/lib/components/DcPullRefresh.vue
+++ b/packages/ui/lib/components/DcPullRefresh.vue
@@ -9,7 +9,7 @@ const $props = withDefaults(
   defineProps<
     { disabled: boolean; refresher: () => Promise<any>; pullDistance?: number } & StyleProps
   >(),
-  { disabled: false, pullDistance: 50 },
+  { disabled: false, pullDistance: 58 },
 )
 
 const isRefreshing = defineModel<boolean>('refreshing', { default: false })
@@ -20,7 +20,6 @@ defineSlots<{ default(): any }>()
 type PullState = 'idle' | 'pulling' | 'ready' | 'refreshing'
 const pullState = ref<PullState>('idle')
 
-// Sync pulling v-model with pullState
 watch(pullState, s => {
   isPulling.value = s !== 'idle'
 })
@@ -28,77 +27,100 @@ watch(pullState, s => {
 // ── drag tracking ──
 const distance = ref(0)
 const startY = ref(0)
-const transitioning = ref(false) // true during spring-back / settle animation
+const startX = ref(0)
+const isDragging = ref(false)
+const transitioning = ref(false)
 const containerRef = ref<HTMLElement>()
-const startScrollTop = ref(0)
 
 const threshold = computed(() => $props.pullDistance)
+const maxDistance = computed(() => threshold.value * 2.2)
+const progress = computed(() => Math.min(distance.value / threshold.value, 1))
+const progressPercent = computed(() => `${Math.round(progress.value * 100)}%`)
+const arrowRotation = computed(() => `${progress.value * 180}deg`)
+const pullText = computed(() => {
+  switch (pullState.value) {
+    case 'ready':
+      return '松手刷新'
+    case 'refreshing':
+      return '正在刷新...'
+    case 'pulling':
+      return '下拉刷新'
+    default:
+      return '下拉刷新'
+  }
+})
 
 function canPull(): boolean {
   const el = containerRef.value
-  if (!el) return false
-  // Allow pull when the container is scrolled to the top
-  return el.scrollTop <= 0
+  return !!el && el.scrollTop <= 0
+}
+
+function resetGesture() {
+  startY.value = 0
+  startX.value = 0
+  isDragging.value = false
+}
+
+function getRubberBandDistance(delta: number) {
+  const dampened = delta * 0.45
+  if (dampened <= threshold.value) return dampened
+
+  const extra = dampened - threshold.value
+  return Math.min(threshold.value + extra * 0.28, maxDistance.value)
 }
 
 // ── touch handlers ──
 function onTouchStart(e: TouchEvent) {
-  if ($props.disabled || isRefreshing.value || transitioning.value) return
-  if (!canPull()) return
+  if ($props.disabled || isRefreshing.value || transitioning.value || !canPull()) return
 
   startY.value = e.touches[0].clientY
-  startScrollTop.value = containerRef.value!.scrollTop
+  startX.value = e.touches[0].clientX
 }
 
 function onTouchMove(e: TouchEvent) {
   if (!startY.value || $props.disabled || isRefreshing.value || transitioning.value) return
 
-  const delta = e.touches[0].clientY - startY.value
+  const touch = e.touches[0]
+  const deltaY = touch.clientY - startY.value
+  const deltaX = Math.abs(touch.clientX - startX.value)
 
-  // Not pulling down or no longer at top
-  if (delta <= 0) {
+  if (deltaY <= 0 || !canPull()) {
     distance.value = 0
     pullState.value = 'idle'
+    resetGesture()
     return
   }
 
-  // Re-check scroll position in case user scrolled up during touch
-  if (!canPull()) {
-    distance.value = 0
-    pullState.value = 'idle'
-    return
-  }
+  if (!isDragging.value && deltaX > deltaY) return
 
-  // Prevent page scrolling when actively pulling down
+  isDragging.value = true
   e.preventDefault()
 
-  // Dampen the drag for natural resistance
-  const d = delta * 0.4
-  distance.value = d
-  pullState.value = d >= threshold.value ? 'ready' : 'pulling'
+  distance.value = getRubberBandDistance(deltaY)
+  pullState.value = distance.value >= threshold.value ? 'ready' : 'pulling'
 }
 
 function onTouchEnd() {
   if (!startY.value || $props.disabled || isRefreshing.value || transitioning.value) return
 
-  startY.value = 0
+  resetGesture()
 
   if (pullState.value === 'ready') {
     doRefresh()
   } else if (distance.value > 0) {
-    springBack(0)
+    settleTo(0)
   }
 }
 
 // ── animation ──
-function springBack(target: number) {
+function settleTo(target: number) {
   transitioning.value = true
   distance.value = target
   if (target === 0) pullState.value = 'idle'
-  // Match CSS transition duration
+
   setTimeout(() => {
     transitioning.value = false
-  }, 350)
+  }, 320)
 }
 
 async function doRefresh() {
@@ -107,19 +129,17 @@ async function doRefresh() {
   transitioning.value = true
   distance.value = threshold.value
 
-  // Let the transition settle before starting the async work
-  await new Promise(r => setTimeout(r, 250))
+  await new Promise(r => setTimeout(r, 220))
   transitioning.value = false
 
   try {
     await $props.refresher()
   } finally {
     isRefreshing.value = false
-    springBack(0)
+    settleTo(0)
   }
 }
 
-// Reset when disabled changes
 watch(
   () => $props.disabled,
   v => {
@@ -127,12 +147,11 @@ watch(
       distance.value = 0
       pullState.value = 'idle'
       transitioning.value = false
-      startY.value = 0
+      resetGesture()
     }
   },
 )
 
-// ── lifecycle: ensure touchmove is non-passive ──
 onMounted(() => {
   containerRef.value?.addEventListener('touchmove', onTouchMove, { passive: false })
 })
@@ -142,68 +161,202 @@ onUnmounted(() => {
 })
 
 // ── derived styles ──
-const arrowRotation = computed(() => (pullState.value === 'ready' ? 180 : 0))
-
 const contentStyle = computed(() => ({
-  transform: `translateY(${distance.value}px)`,
-  transition: transitioning.value ? 'transform 0.35s cubic-bezier(0.25, 0.1, 0.25, 1)' : 'none',
+  transform: `translate3d(0, ${distance.value}px, 0)`,
+  transition: transitioning.value ? 'transform 0.32s cubic-bezier(0.22, 1, 0.36, 1)' : 'none',
   willChange: transitioning.value ? undefined : 'transform',
 }))
 
 const indicatorStyle = computed(() => ({
-  height: `${distance.value}px`,
+  height: `${Math.max(distance.value, pullState.value === 'refreshing' ? threshold.value : 0)}px`,
   opacity: pullState.value !== 'idle' ? 1 : 0,
-  transition: pullState.value === 'idle' && distance.value === 0 ? 'opacity 0.2s ease' : 'none',
+  transition:
+    transitioning.value || pullState.value === 'idle'
+      ? 'height 0.32s cubic-bezier(0.22, 1, 0.36, 1), opacity 0.18s ease'
+      : 'none',
+}))
+
+const faceStyle = computed(() => ({
+  transform: `translateY(${8 - progress.value * 8}px) scale(${0.86 + progress.value * 0.14})`,
+  opacity: 0.35 + progress.value * 0.65,
+}))
+
+const bubbleStyle = computed(() => ({
+  '--dc-pull-progress': progressPercent.value,
+  '--dc-pull-arrow-rotate': arrowRotation.value,
 }))
 </script>
 
 <template>
   <div
     ref="containerRef"
-    :class="cn('relative overflow-x-hidden overflow-y-auto', $props.class)"
+    :class="cn('relative overflow-x-hidden overflow-y-auto overscroll-contain', $props.class)"
     :style="$props.style"
     @touchstart.passive="onTouchStart"
     @touchend="onTouchEnd"
+    @touchcancel="onTouchEnd"
   >
-    <!-- Pull indicator area -->
     <div
-      class="absolute top-0 right-0 left-0 flex items-end justify-center overflow-hidden"
+      class="pointer-events-none absolute top-0 right-0 left-0 z-1 flex items-end justify-center overflow-hidden"
       :style="indicatorStyle"
+      aria-hidden="true"
     >
-      <div class="flex items-center gap-2 pb-2 text-sm" style="color: var(--van-gray-5)">
-        <!-- Arrow icon -->
-        <svg
-          width="16"
-          height="16"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          :style="{ transform: `rotate(${arrowRotation}deg)`, transition: 'transform 0.2s ease' }"
-        >
-          <path d="M12 19V5" />
-          <path d="M5 12l7-7 7 7" />
-        </svg>
+      <div class="dc-pull-refresh__stage pb-2" :style="bubbleStyle">
+        <div class="dc-pull-refresh__mascot" :style="faceStyle">
+          <div class="dc-pull-refresh__antenna" />
+          <div class="dc-pull-refresh__face">
+            <span class="dc-pull-refresh__eye dc-pull-refresh__eye--left" />
+            <span class="dc-pull-refresh__eye dc-pull-refresh__eye--right" />
+            <span class="dc-pull-refresh__mouth" />
+          </div>
+        </div>
 
-        <!-- Refreshing: show spinner -->
-        <template v-if="pullState === 'refreshing'">
-          <DcLoading size="16px" />
-          <span>正在刷新...</span>
-        </template>
-
-        <!-- Pulling / ready: show text -->
-        <template v-else>
-          <span v-if="pullState === 'ready'">释放刷新</span>
-          <span v-else>下拉刷新</span>
-        </template>
+        <div class="dc-pull-refresh__bubble">
+          <DcLoading v-if="pullState === 'refreshing'" size="14px" />
+          <span v-else class="dc-pull-refresh__arrow">↓</span>
+          <span>{{ pullText }}</span>
+        </div>
       </div>
     </div>
 
-    <!-- Content area -->
     <div :style="contentStyle">
       <slot />
     </div>
   </div>
 </template>
+
+<style scoped>
+.dc-pull-refresh__stage {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: #fb7299;
+  font-size: 13px;
+  line-height: 1;
+}
+
+.dc-pull-refresh__mascot {
+  position: relative;
+  width: 34px;
+  height: 28px;
+  transition: opacity 0.18s ease;
+}
+
+.dc-pull-refresh__antenna {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 16px;
+  height: 10px;
+  border-top: 2px solid currentColor;
+  border-left: 2px solid currentColor;
+  border-radius: 10px 0 0;
+  transform: translateX(-15%) rotate(22deg);
+  transform-origin: bottom left;
+}
+
+.dc-pull-refresh__antenna::after {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  width: 5px;
+  height: 5px;
+  background: currentColor;
+  border-radius: 999px;
+  content: '';
+}
+
+.dc-pull-refresh__face {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 23px;
+  overflow: hidden;
+  background: #fff;
+  border: 2px solid currentColor;
+  border-radius: 7px;
+  box-shadow: 0 5px 14px rgb(251 114 153 / 18%);
+}
+
+.dc-pull-refresh__face::before,
+.dc-pull-refresh__face::after {
+  position: absolute;
+  top: 6px;
+  width: 4px;
+  height: 8px;
+  background: #fff;
+  border: 2px solid currentColor;
+  content: '';
+}
+
+.dc-pull-refresh__face::before {
+  left: -4px;
+  border-radius: 4px 0 0 4px;
+}
+
+.dc-pull-refresh__face::after {
+  right: -4px;
+  border-radius: 0 4px 4px 0;
+}
+
+.dc-pull-refresh__eye {
+  position: absolute;
+  top: 8px;
+  width: 4px;
+  height: 4px;
+  background: currentColor;
+  border-radius: 999px;
+}
+
+.dc-pull-refresh__eye--left {
+  left: 9px;
+}
+
+.dc-pull-refresh__eye--right {
+  right: 9px;
+}
+
+.dc-pull-refresh__mouth {
+  position: absolute;
+  right: 13px;
+  bottom: 5px;
+  left: 13px;
+  height: 4px;
+  border-bottom: 2px solid currentColor;
+  border-radius: 0 0 999px 999px;
+}
+
+.dc-pull-refresh__bubble {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  min-width: 92px;
+  gap: 5px;
+  padding: 7px 10px;
+  overflow: hidden;
+  color: #fb7299;
+  background: rgb(251 114 153 / 10%);
+  border: 1px solid rgb(251 114 153 / 18%);
+  border-radius: 999px;
+}
+
+.dc-pull-refresh__bubble::before {
+  position: absolute;
+  inset: 0;
+  width: var(--dc-pull-progress);
+  background: linear-gradient(90deg, rgb(251 114 153 / 14%), rgb(251 114 153 / 4%));
+  content: '';
+}
+
+.dc-pull-refresh__bubble > * {
+  position: relative;
+  z-index: 1;
+}
+
+.dc-pull-refresh__arrow {
+  font-size: 14px;
+  transform: rotate(var(--dc-pull-arrow-rotate));
+  transition: transform 0.18s ease;
+}
+</style>


### PR DESCRIPTION
### Motivation
- Improve the mobile pull-to-refresh UX to be closer to Bilibili's polished interaction and visuals. 
- Make touch handling more robust on mobile by preventing accidental horizontal swipes, adding rubber-band resistance, and smoothing settle/refresh transitions.

### Description
- Reimplemented touch logic in `DcPullRefresh` to add axis gating (ignore horizontal drags), a dampened rubber-band distance calculation, `touchcancel` handling, and a smoother settle animation via `settleTo`/`transitioning` state. 
- Increased default pull threshold from `50` to `58` and switched content transform to `translate3d` for better GPU compositing. 
- Replaced the simple arrow indicator with a Bilibili-inspired mascot + progress bubble component, driven by computed `progress`, `faceStyle`, and `bubbleStyle`, while preserving the existing `refreshing` / `pulling` v-model API and slot structure. 
- All changes are contained in `packages/ui/lib/components/DcPullRefresh.vue` (new touch heuristics, visual markup and scoped CSS). 

### Testing
- Attempted to run `vp install` but the global `vp` binary is not available in this environment so installation could not be executed. 
- Ran `./node_modules/.bin/vp check` / formatting but it failed due to workspace package export/style artifacts (resolver errors for `@delta-comic/ui/style.css`). 
- Ran `./node_modules/.bin/vp test` which executed but test suites failed because the workspace could not resolve the `@delta-comic/model` package entry (pre-existing workspace configuration/resolution issues). 
- Ran `vue-tsc` for the `ui` package which reported unresolved workspace package/type errors; these failures are unrelated to the `DcPullRefresh` implementation itself and stem from workspace package resolution in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d761a0614832ca29242f1dfd2892f)