### PR TITLE
fix(utils): replace Pinia-based temp store with singleton reactive TempStore

### DIFF
--- a/packages/utils/lib/temp.ts
+++ b/packages/utils/lib/temp.ts
@@ -1,42 +1,47 @@
-import { defineStore } from 'pinia'
 import { reactive, shallowReactive, type Reactive } from 'vue'
 
 import { useGlobalVar } from './var'
 
-const _useTemp = useGlobalVar(
-  defineStore('core:temp', helper => {
-    const tempBase = shallowReactive(new Map<string, any>())
-    const $apply = <T extends object>(id: string, def: () => T) => {
-      id = `reactive:${id}`
-      if (!tempBase.has(id)) tempBase.set(id, reactive(def()))
-      const store: Reactive<T> = tempBase.get(id)
-      return store
-    }
-    const $has = helper.action((id: string): boolean => {
-      id = `reactive:${id}`
-      return tempBase.has(id)
-    }, 'has')
-    const $onlyGet = helper.action(<T extends object>(id: string): Reactive<T> => {
-      id = `reactive:${id}`
-      return tempBase.get(id)
-    }, 'onlyGet')
-    const $applyRaw = helper.action(<T extends object>(id: string, def: () => T) => {
-      id = `raw:${id}`
-      if (!tempBase.has(id)) tempBase.set(id, def())
-      const store: T = tempBase.get(id)
-      return store
-    }, 'applyRaw')
-    const $hasRaw = helper.action((id: string): boolean => {
-      id = `raw:${id}`
-      return tempBase.has(id)
-    }, 'hasRaw')
-    const $onlyGetRaw = helper.action(<T extends object>(id: string): Reactive<T> => {
-      id = `raw:${id}`
-      return tempBase.get(id)
-    }, 'onlyGetRaw')
-    return { $apply, $has, $onlyGet, $applyRaw, $hasRaw, $onlyGetRaw }
-  }),
-  'store/temp',
-)
+class TempStore {
+  private readonly tempBase = shallowReactive(new Map<string, unknown>())
 
-export const useTemp = () => _useTemp(window.$api.piniaInstance)
+  $apply<T extends object>(id: string, def: () => T): Reactive<T> {
+    const key = this.getReactiveKey(id)
+    if (!this.tempBase.has(key)) this.tempBase.set(key, reactive(def()))
+    return this.tempBase.get(key) as Reactive<T>
+  }
+
+  $has(id: string): boolean {
+    return this.tempBase.has(this.getReactiveKey(id))
+  }
+
+  $onlyGet<T extends object>(id: string): Reactive<T> | undefined {
+    return this.tempBase.get(this.getReactiveKey(id)) as Reactive<T> | undefined
+  }
+
+  $applyRaw<T extends object>(id: string, def: () => T): T {
+    const key = this.getRawKey(id)
+    if (!this.tempBase.has(key)) this.tempBase.set(key, def())
+    return this.tempBase.get(key) as T
+  }
+
+  $hasRaw(id: string): boolean {
+    return this.tempBase.has(this.getRawKey(id))
+  }
+
+  $onlyGetRaw<T extends object>(id: string): T | undefined {
+    return this.tempBase.get(this.getRawKey(id)) as T | undefined
+  }
+
+  private getReactiveKey(id: string): string {
+    return `reactive:${id}`
+  }
+
+  private getRawKey(id: string): string {
+    return `raw:${id}`
+  }
+}
+
+const temp = useGlobalVar(new TempStore(), 'store/temp')
+
+export const useTemp = () => temp


### PR DESCRIPTION
### Motivation
- The `utils` temp module used a Pinia `defineStore` and required `window.$api.piniaInstance` during app startup, which caused startup hang issues.
- Replace Pinia with a minimal native implementation that still provides a shared, reactive temporary storage API without depending on Pinia.

### Description
- Removed `defineStore` usage and implemented a `TempStore` singleton class backed by a `shallowReactive(new Map())` to store reactive and raw entries. 
- Preserved the existing `useTemp()` API surface (`$apply`, `$has`, `$onlyGet`, `$applyRaw`, `$hasRaw`, `$onlyGetRaw`) so callers do not need to change. 
- Kept global/shared behavior by registering the singleton with `useGlobalVar(new TempStore(), 'store/temp')` so the data remains accessible across the app without a Pinia instance. 
- Updated `packages/utils/lib/temp.ts` to the new implementation and removed the Pinia import.

### Testing
- Attempted full workspace run: `vp install` failed due to an external registry network error and could not complete dependency install. 
- `vp check` was run but failed early because of pre-existing unresolved references to `@delta-comic/ui/style.css` in other packages. 
- `vp test` executed; some test suites ran but test failures were unrelated to this change and showed existing package resolution issues for `@delta-comic/model` in DB tests. 
- Targeted verification for the modified file passed local tooling runs (`tsgo`/`oxlint`) against `packages/utils/lib/temp.ts` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ec7d456ec832c9276edcd366d55f0)